### PR TITLE
fix(push): fixes push notifications not showing (#100)

### DIFF
--- a/app/scripts/renderer/pushbullet/push.js
+++ b/app/scripts/renderer/pushbullet/push.js
@@ -284,7 +284,9 @@ let generateNotificationImage = (push) => {
 
     if (!!push.sender_email) {
         const target = window.pb.targets.by_email(push.sender_email)
-        iconChat = target.image_url
+        if (target && target.hasOwnProperty('image_url')) {
+            iconChat = target.image_url
+        }
     }
 
     // Mirroring Image


### PR DESCRIPTION
<!--- ⬆️ Add your Pull Request title in the "Title" field above ⬆️ -->

## 📋 Description
<!---
Add a short description of the changes.
-->
Fixes push notifications not showing on any desktops by checking whether target has image_url when retrieving iconChat, avoiding an exception thrown as described in #100.

## 🗂 Type
<!---
Check all applying boxes.
-->
- [ ] 🍾 Feature
- [x] 🚨 Bugfix
- [ ] 📒 Documentation
- [ ] 👷 Internals

## 🔥 Severity
<!---
Check one box.
-->
- [x] 💎 Non-Breaking Changes
- [ ] 💔 Breaking Changes

## 🖥 Platforms
<!---
Check all platforms affected by the changes.
-->
- [x] 🍏 macOS
- [x] 💾 Windows
- [x] 🐧 Linux

## 🛃 Tests
<!---
Check one box.
-->
- [x] My changes have been tested manually.
- [ ] My changes are covered by automated testing methods.

## 👨‍🎓 Miscellaneous
<!---
Check all applying boxes.
-->
- [x] My changes follow the style guide.
- [ ] My changes require updates to the documentation.

